### PR TITLE
Rename VoiceInit extra_data to sampling_rate

### DIFF
--- a/src/demo/message/voice.rs
+++ b/src/demo/message/voice.rs
@@ -6,7 +6,7 @@ use crate::{ReadResult, Stream};
 pub struct VoiceInitMessage {
     codec: String,
     quality: u8,
-    extra_data: u16,
+    sampling_rate: u16,
 }
 
 impl BitRead<LittleEndian> for VoiceInitMessage {
@@ -14,7 +14,7 @@ impl BitRead<LittleEndian> for VoiceInitMessage {
         let codec = stream.read()?;
         let quality = stream.read()?;
 
-        let extra_data = if quality == 255 {
+        let sampling_rate = if quality == 255 {
             stream.read()?
         } else if codec == "vaudio_celt" {
             11025
@@ -25,7 +25,7 @@ impl BitRead<LittleEndian> for VoiceInitMessage {
         Ok(VoiceInitMessage {
             codec,
             quality,
-            extra_data,
+            sampling_rate,
         })
     }
 }


### PR DESCRIPTION
When quality is 255, an extra field is included in the VoiceInit
message. This field is the sampling rate for the voice codec selected.
This commit simply renames that field from `extra_data` as it is
currently known.

Interestingly, this field is present, but doesn't match when CELT HQ is
used. If `sv_voicecodec = vaudio_celt_high` on the server, the sampling
rate is still specified as 22050 Hz(as for CELT non-HQ) rather than the
expected 44100 Hz.  The client code will instead look for `vaudio_celt`
and `vaudio_celt_high` as codec name, and use these to to index a lookup
table that specifies the correct sampling rate and frame size. For
`vaudio_celt` 22050 Hz with 512 samples per frame is used, while
`vaudio_celt_high` uses 44100 Hz with 1024 samples per frame.