### PR TITLE
Made various modules public

### DIFF
--- a/src/demo/data/mod.rs
+++ b/src/demo/data/mod.rs
@@ -1,3 +1,3 @@
-mod userinfo;
+pub mod userinfo;
 
 pub use userinfo::UserInfo;

--- a/src/demo/parser/mod.rs
+++ b/src/demo/parser/mod.rs
@@ -11,12 +11,12 @@ pub use crate::demo::parser::handler::{DemoHandler, MessageHandler, NullHandler}
 pub use crate::demo::parser::state::ParserState;
 use crate::Stream;
 
-mod analyser;
-mod error;
+pub mod analyser;
+pub mod error;
 pub mod gamestateanalyser;
 pub mod handler;
-mod messagetypeanalyser;
-mod state;
+pub mod messagetypeanalyser;
+pub mod state;
 
 pub use self::error::*;
 use crate::demo::parser::handler::BorrowMessageHandler;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ pub use crate::demo::{
 
 pub(crate) mod consthash;
 pub mod demo;
-mod nullhasher;
+pub(crate) mod nullhasher;
 
 #[cfg(test)]
 #[track_caller]


### PR DESCRIPTION
A number of modules that seem as though they should be public are not, this fixes it. Here is my reasoning for each change

* `demo::parser::analyser`:
This is the big one. It lets users of the crate access various important types that appear in `MatchState`, such as `ChatMessage`, `UserInfo`, `Death`, and `Round`, as well as help users figure out what `Analyser` is (as it appears in `DemoParser`) and provide a crucial link in the documentation so people can find out that it returns `MatchState` as part of its `MessageHandler` impl

* `demo::parser::state`:
Gives access to `StaticBaseline` and `DemoMeta`, which both appear in public fields in `ParserState`

* `demo::data::userinfo`:
Gives access to `PlayerInfo` struct, which appears in the a public field of the `UserInfo` struct

The following changes were mainly done for consistency but aren't necessarily needed

* `demo::parser::error`:
All the public types in this module are already re-exported in `demo::parser`, but it feels strange to have this module be private in the first place

* `demo::parser::messagetypeanalyser`:
The public type in here is are also re-exported in `demo::parser`, so this isn't necessarily needed

Lastly while I didn't make the `nullhasher` module public, I changed it to `pub(crate)` just so it is more clear it is internal. I debated making this public because `NullHasherBuilder` appears as hasher for the `HashMap`s in `ParserState` (in public fields that is), but decided against it as I don't think this type is useful outside of the crate and there isn't any vital knowledge users of the crate need to know about `NullHasher` or `NullHasherBuilder`

The one remaining question after this is what to do with all the re-exports, as there are a number of re-exports that are no longer needed just for the project to compile. A later PR may be needed to clean those up, with a version bump of course as it would be a breaking change