### PR TITLE
Fix typos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "tf-demo-parser"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "better-panic",
  "bitbuffer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tf-demo-parser"
 description = "parser for tf2 demo files"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Robin Appelman <robin@icewind.nl>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/schema.json
+++ b/schema.json
@@ -28,7 +28,7 @@
         "type": {
           "type": "string",
           "enum": [
-            "Sigon"
+            "Signon"
           ]
         }
       }
@@ -11497,7 +11497,7 @@
             "type": {
               "type": "string",
               "enum": [
-                "SigOnState"
+                "SignOnState"
               ]
             }
           }

--- a/src/bin/reencode.rs
+++ b/src/bin/reencode.rs
@@ -13,7 +13,7 @@ use tf_demo_parser::demo::parser::{DemoHandler, Encode, RawPacketStream};
 use tf_demo_parser::{Demo, ParseError};
 
 const COPY_TYPES: &[PacketType] = &[
-    // PacketType::Sigon,
+    // PacketType::Signon,
     // PacketType::Message,
     // PacketType::SyncTick,   // bit perfect
     // PacketType::ConsoleCmd, // bit perfect
@@ -67,7 +67,7 @@ fn main() -> Result<(), MainError> {
                 packet_bits.write(&mut out_stream)?;
             } else {
                 match &mut packet {
-                    Packet::Sigon(message_packet) | Packet::Message(message_packet)
+                    Packet::Signon(message_packet) | Packet::Message(message_packet)
                         if strip_pov =>
                     {
                         message_packet.meta.view_angles = Default::default();
@@ -117,7 +117,7 @@ fn header_fixup(header: &mut Header, mut packets: RawPacketStream) -> Result<(),
     while let Some(packet) = packets.next(&handler.state_handler)? {
         ticks = packet.tick();
 
-        if let Packet::Sigon(message_packet) = &packet {
+        if let Packet::Signon(message_packet) = &packet {
             for message in &message_packet.messages {
                 if let Message::SetConVar(SetConVarMessage { vars, .. }) = message {
                     for cvar in vars {

--- a/src/demo/header.rs
+++ b/src/demo/header.rs
@@ -19,5 +19,5 @@ pub struct Header {
     pub duration: f32,
     pub ticks: u32,
     pub frames: u32,
-    pub sigon: u32,
+    pub signon: u32,
 }

--- a/src/demo/message/mod.rs
+++ b/src/demo/message/mod.rs
@@ -38,7 +38,7 @@ pub enum MessageType {
     NetTick = 3,
     StringCmd = 4,
     SetConVar = 5,
-    SigOnState = 6,
+    SignOnState = 6,
     Print = 7,
     ServerInfo = 8,
     ClassInfo = 10,
@@ -73,7 +73,7 @@ pub enum Message<'a> {
     NetTick(NetTickMessage),
     StringCmd(StringCmdMessage),
     SetConVar(SetConVarMessage),
-    SigOnState(SignOnStateMessage),
+    SignOnState(SignOnStateMessage),
     Print(PrintMessage),
     ServerInfo(Box<ServerInfoMessage>),
     ClassInfo(ClassInfoMessage),
@@ -113,7 +113,7 @@ impl<'a> Message<'a> {
             Message::NetTick(_) => MessageType::NetTick,
             Message::StringCmd(_) => MessageType::StringCmd,
             Message::SetConVar(_) => MessageType::SetConVar,
-            Message::SigOnState(_) => MessageType::SigOnState,
+            Message::SignOnState(_) => MessageType::SignOnState,
             Message::Print(_) => MessageType::Print,
             Message::ServerInfo(_) => MessageType::ServerInfo,
             Message::ClassInfo(_) => MessageType::ClassInfo,
@@ -150,8 +150,8 @@ impl<'a> Message<'a> {
             MessageType::NetTick => Message::NetTick(NetTickMessage::parse(stream, state)?),
             MessageType::StringCmd => Message::StringCmd(StringCmdMessage::parse(stream, state)?),
             MessageType::SetConVar => Message::SetConVar(SetConVarMessage::parse(stream, state)?),
-            MessageType::SigOnState => {
-                Message::SigOnState(SignOnStateMessage::parse(stream, state)?)
+            MessageType::SignOnState => {
+                Message::SignOnState(SignOnStateMessage::parse(stream, state)?)
             }
             MessageType::Print => Message::Print(PrintMessage::parse(stream, state)?),
             MessageType::ServerInfo => {
@@ -209,7 +209,7 @@ impl<'a> Message<'a> {
             MessageType::NetTick => NetTickMessage::parse_skip(stream, state),
             MessageType::StringCmd => StringCmdMessage::parse_skip(stream, state),
             MessageType::SetConVar => SetConVarMessage::parse_skip(stream, state),
-            MessageType::SigOnState => SignOnStateMessage::parse_skip(stream, state),
+            MessageType::SignOnState => SignOnStateMessage::parse_skip(stream, state),
             MessageType::Print => PrintMessage::parse_skip(stream, state),
             MessageType::ServerInfo => ServerInfoMessage::parse_skip(stream, state),
             MessageType::ClassInfo => ClassInfoMessage::parse_skip(stream, state),
@@ -244,7 +244,7 @@ impl Encode for Message<'_> {
             Message::NetTick(message) => message.encode(stream, state),
             Message::StringCmd(message) => message.encode(stream, state),
             Message::SetConVar(message) => message.encode(stream, state),
-            Message::SigOnState(message) => message.encode(stream, state),
+            Message::SignOnState(message) => message.encode(stream, state),
             Message::Print(message) => message.encode(stream, state),
             Message::ServerInfo(message) => message.encode(stream, state),
             Message::ClassInfo(message) => message.encode(stream, state),

--- a/src/demo/packet/mod.rs
+++ b/src/demo/packet/mod.rs
@@ -26,7 +26,7 @@ pub mod usercmd;
 #[serde(bound(deserialize = "'a: 'static"))]
 #[serde(tag = "type")]
 pub enum Packet<'a> {
-    Sigon(MessagePacket<'a>),
+    Signon(MessagePacket<'a>),
     Message(MessagePacket<'a>),
     SyncTick(SyncTickPacket),
     ConsoleCmd(ConsoleCmdPacket),
@@ -39,7 +39,7 @@ pub enum Packet<'a> {
 impl Packet<'_> {
     pub fn tick(&self) -> u32 {
         match self {
-            Packet::Sigon(msg) => msg.tick,
+            Packet::Signon(msg) => msg.tick,
             Packet::Message(msg) => msg.tick,
             Packet::SyncTick(msg) => msg.tick,
             Packet::ConsoleCmd(msg) => msg.tick,
@@ -52,7 +52,7 @@ impl Packet<'_> {
 
     pub fn set_tick(&mut self, tick: u32) {
         match self {
-            Packet::Sigon(msg) => msg.tick = tick,
+            Packet::Signon(msg) => msg.tick = tick,
             Packet::Message(msg) => msg.tick = tick,
             Packet::SyncTick(msg) => msg.tick = tick,
             Packet::ConsoleCmd(msg) => msg.tick = tick,
@@ -69,7 +69,7 @@ impl Packet<'_> {
 #[discriminant_bits = 8]
 #[repr(u8)]
 pub enum PacketType {
-    Sigon = 1,
+    Signon = 1,
     Message = 2,
     SyncTick = 3,
     ConsoleCmd = 4,
@@ -82,7 +82,7 @@ pub enum PacketType {
 impl Packet<'_> {
     pub fn packet_type(&self) -> PacketType {
         match self {
-            Packet::Sigon(_) => PacketType::Sigon,
+            Packet::Signon(_) => PacketType::Signon,
             Packet::Message(_) => PacketType::Message,
             Packet::SyncTick(_) => PacketType::SyncTick,
             Packet::ConsoleCmd(_) => PacketType::ConsoleCmd,
@@ -100,7 +100,7 @@ impl<'a> Parse<'a> for Packet<'a> {
         let _span = span!(Level::INFO, "reading packet", packet_type = ?packet_type).entered();
         event!(Level::INFO, "parsing packet");
         Ok(match packet_type {
-            PacketType::Sigon => Packet::Sigon(MessagePacket::parse(stream, state)?),
+            PacketType::Signon => Packet::Signon(MessagePacket::parse(stream, state)?),
             PacketType::Message => Packet::Message(MessagePacket::parse(stream, state)?),
             PacketType::SyncTick => Packet::SyncTick(SyncTickPacket::parse(stream, state)?),
             PacketType::ConsoleCmd => Packet::ConsoleCmd(ConsoleCmdPacket::parse(stream, state)?),
@@ -118,7 +118,7 @@ impl Encode for Packet<'_> {
     fn encode(&self, stream: &mut BitWriteStream<LittleEndian>, state: &ParserState) -> Result<()> {
         self.packet_type().write(stream)?;
         match self {
-            Packet::Sigon(inner) => inner.encode(stream, state),
+            Packet::Signon(inner) => inner.encode(stream, state),
             Packet::Message(inner) => inner.encode(stream, state),
             Packet::SyncTick(inner) => inner.encode(stream, state),
             Packet::ConsoleCmd(inner) => inner.encode(stream, state),

--- a/src/demo/parser/analyser.rs
+++ b/src/demo/parser/analyser.rs
@@ -18,16 +18,16 @@ use std::convert::TryFrom;
 use std::ops::{Index, IndexMut};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct ChatMassage {
+pub struct ChatMessage {
     pub kind: ChatMessageKind,
     pub from: String,
     pub text: String,
     pub tick: u32,
 }
 
-impl ChatMassage {
+impl ChatMessage {
     pub fn from_message(message: &SayText2Message, tick: u32) -> Self {
-        ChatMassage {
+        ChatMessage {
             kind: message.kind,
             from: message.from.clone().unwrap_or_default(),
             text: message.plain_text(),
@@ -356,7 +356,7 @@ impl Analyser {
             } else {
                 self.state
                     .chat
-                    .push(ChatMassage::from_message(text_message, tick));
+                    .push(ChatMessage::from_message(text_message, tick));
             }
         }
     }
@@ -406,7 +406,7 @@ impl Analyser {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct MatchState {
-    pub chat: Vec<ChatMassage>,
+    pub chat: Vec<ChatMessage>,
     pub users: BTreeMap<UserId, UserInfo>,
     pub deaths: Vec<Death>,
     pub rounds: Vec<Round>,

--- a/src/demo/parser/handler.rs
+++ b/src/demo/parser/handler.rs
@@ -94,7 +94,7 @@ impl<'a, T: MessageHandler> DemoHandler<'a, T> {
                     self.handle_string_table(table)
                 }
             }
-            Packet::Message(packet) | Packet::Sigon(packet) => {
+            Packet::Message(packet) | Packet::Signon(packet) => {
                 //self.tick = packet.tick;
                 for message in packet.messages {
                     match message {

--- a/tests/reencode.rs
+++ b/tests/reencode.rs
@@ -69,8 +69,8 @@ fn re_encode_test(input_file: &str) {
         assert_eq!(packet.packet_type(), re_decoded.packet_type());
         match (&packet, &re_decoded) {
             (
-                Packet::Message(msg) | Packet::Sigon(msg),
-                Packet::Message(re_msg) | Packet::Sigon(re_msg),
+                Packet::Message(msg) | Packet::Signon(msg),
+                Packet::Message(re_msg) | Packet::Signon(re_msg),
             ) => {
                 assert_eq!(msg.tick, re_msg.tick);
                 assert_eq!(msg.meta, re_msg.meta);


### PR DESCRIPTION
May break some existing code, hence the version bump. It'd be very useful to have recent changes (18afd4f) on crates.io anyways.