### PR TITLE
Distinguish between client and server ticks

### DIFF
--- a/benches/iai.rs
+++ b/benches/iai.rs
@@ -12,7 +12,13 @@ impl MessageHandler for AllMessages {
         true
     }
 
-    fn handle_message(&mut self, message: &Message, _server_tick: u32, _client_tick: u32, _parser_state: &ParserState) {
+    fn handle_message(
+        &mut self,
+        message: &Message,
+        _server_tick: u32,
+        _client_tick: u32,
+        _parser_state: &ParserState,
+    ) {
         black_box(message);
     }
 

--- a/benches/iai.rs
+++ b/benches/iai.rs
@@ -12,7 +12,7 @@ impl MessageHandler for AllMessages {
         true
     }
 
-    fn handle_message(&mut self, message: &Message, _tick: u32, _parser_state: &ParserState) {
+    fn handle_message(&mut self, message: &Message, _server_tick: u32, _client_tick: u32, _parser_state: &ParserState) {
         black_box(message);
     }
 

--- a/examples/allprops.rs
+++ b/examples/allprops.rs
@@ -42,7 +42,13 @@ impl MessageHandler for PropAnalyzer {
         matches!(message_type, MessageType::PacketEntities)
     }
 
-    fn handle_message(&mut self, message: &Message, _server_tick: u32, _client_tick:u32, _parser_state: &ParserState) {
+    fn handle_message(
+        &mut self,
+        message: &Message,
+        _server_tick: u32,
+        _client_tick: u32,
+        _parser_state: &ParserState,
+    ) {
         if let Message::PacketEntities(message) = message {
             for entity in &message.entities {
                 for prop in &entity.props {

--- a/examples/allprops.rs
+++ b/examples/allprops.rs
@@ -42,7 +42,7 @@ impl MessageHandler for PropAnalyzer {
         matches!(message_type, MessageType::PacketEntities)
     }
 
-    fn handle_message(&mut self, message: &Message, _tick: u32, _parser_state: &ParserState) {
+    fn handle_message(&mut self, message: &Message, _server_tick: u32, _client_tick:u32, _parser_state: &ParserState) {
         if let Message::PacketEntities(message) = message {
             for entity in &message.entities {
                 for prop in &entity.props {

--- a/src/demo/parser/analyser.rs
+++ b/src/demo/parser/analyser.rs
@@ -378,7 +378,13 @@ impl MessageHandler for Analyser {
         )
     }
 
-    fn handle_message(&mut self, message: &Message, server_tick: u32, _client_tick: u32, _parser_state: &ParserState) {
+    fn handle_message(
+        &mut self,
+        message: &Message,
+        server_tick: u32,
+        _client_tick: u32,
+        _parser_state: &ParserState,
+    ) {
         if self.state.start_tick == 0 {
             self.state.start_tick = server_tick;
         }

--- a/src/demo/parser/analyser.rs
+++ b/src/demo/parser/analyser.rs
@@ -378,16 +378,16 @@ impl MessageHandler for Analyser {
         )
     }
 
-    fn handle_message(&mut self, message: &Message, tick: u32, _parser_state: &ParserState) {
+    fn handle_message(&mut self, message: &Message, server_tick: u32, _client_tick: u32, _parser_state: &ParserState) {
         if self.state.start_tick == 0 {
-            self.state.start_tick = tick;
+            self.state.start_tick = server_tick;
         }
         match message {
             Message::ServerInfo(message) => {
                 self.state.interval_per_tick = message.interval_per_tick
             }
-            Message::GameEvent(message) => self.handle_event(&message.event, tick),
-            Message::UserMessage(message) => self.handle_user_message(message, tick),
+            Message::GameEvent(message) => self.handle_event(&message.event, server_tick),
+            Message::UserMessage(message) => self.handle_user_message(message, server_tick),
             _ => {}
         }
     }

--- a/src/demo/parser/gamestateanalyser.rs
+++ b/src/demo/parser/gamestateanalyser.rs
@@ -303,7 +303,6 @@ impl GameState {
 #[derive(Default, Debug)]
 pub struct GameStateAnalyser {
     pub state: GameState,
-    tick: u32,
     class_names: Vec<ServerClassName>, // indexed by ClassId
 }
 
@@ -317,7 +316,7 @@ impl MessageHandler for GameStateAnalyser {
         )
     }
 
-    fn handle_message(&mut self, message: &Message, _tick: u32, parser_state: &ParserState) {
+    fn handle_message(&mut self, message: &Message, _server_tick: u32, client_tick: u32, parser_state: &ParserState) {
         match message {
             Message::PacketEntities(message) => {
                 for entity in &message.entities {
@@ -326,7 +325,7 @@ impl MessageHandler for GameStateAnalyser {
             }
             Message::GameEvent(GameEventMessage { event, .. }) => match event {
                 GameEvent::PlayerDeath(death) => {
-                    self.state.kills.push(Kill::new(self.tick, death.as_ref()))
+                    self.state.kills.push(Kill::new(client_tick, death.as_ref()))
                 }
                 GameEvent::RoundStart(_) => {
                     self.state.buildings.clear();
@@ -374,12 +373,11 @@ impl MessageHandler for GameStateAnalyser {
 
     fn handle_packet_meta(
         &mut self,
-        tick: u32,
+        client_tick: u32,
         _meta: &MessagePacketMeta,
         _parser_state: &ParserState,
     ) {
-        self.state.tick = tick;
-        self.tick = tick;
+        self.state.tick = client_tick;
     }
 
     fn into_output(self, _state: &ParserState) -> Self::Output {

--- a/src/demo/parser/gamestateanalyser.rs
+++ b/src/demo/parser/gamestateanalyser.rs
@@ -316,7 +316,13 @@ impl MessageHandler for GameStateAnalyser {
         )
     }
 
-    fn handle_message(&mut self, message: &Message, _server_tick: u32, client_tick: u32, parser_state: &ParserState) {
+    fn handle_message(
+        &mut self,
+        message: &Message,
+        _server_tick: u32,
+        client_tick: u32,
+        parser_state: &ParserState,
+    ) {
         match message {
             Message::PacketEntities(message) => {
                 for entity in &message.entities {
@@ -324,9 +330,10 @@ impl MessageHandler for GameStateAnalyser {
                 }
             }
             Message::GameEvent(GameEventMessage { event, .. }) => match event {
-                GameEvent::PlayerDeath(death) => {
-                    self.state.kills.push(Kill::new(client_tick, death.as_ref()))
-                }
+                GameEvent::PlayerDeath(death) => self
+                    .state
+                    .kills
+                    .push(Kill::new(client_tick, death.as_ref())),
                 GameEvent::RoundStart(_) => {
                     self.state.buildings.clear();
                 }

--- a/src/demo/parser/handler.rs
+++ b/src/demo/parser/handler.rs
@@ -16,7 +16,14 @@ pub trait MessageHandler {
 
     fn handle_header(&mut self, _header: &Header) {}
 
-    fn handle_message(&mut self, _message: &Message, _server_tick: u32, _client_tick: u32, _parser_state: &ParserState) {}
+    fn handle_message(
+        &mut self,
+        _message: &Message,
+        _server_tick: u32,
+        _client_tick: u32,
+        _parser_state: &ParserState,
+    ) {
+    }
 
     fn handle_string_entry(
         &mut self,
@@ -184,8 +191,12 @@ impl<'a, T: MessageHandler> DemoHandler<'a, T> {
     pub fn handle_message(&mut self, message: Message<'a>, client_tick: u32) {
         let message_type = message.get_message_type();
         if T::does_handle(message_type) {
-            self.analyser
-                .handle_message(&message, self.server_tick, client_tick, &self.state_handler);
+            self.analyser.handle_message(
+                &message,
+                self.server_tick,
+                client_tick,
+                &self.state_handler,
+            );
         }
         self.state_handler.handle_message(message, self.server_tick);
     }

--- a/src/demo/parser/messagetypeanalyser.rs
+++ b/src/demo/parser/messagetypeanalyser.rs
@@ -16,7 +16,13 @@ impl MessageHandler for MessageTypeAnalyser {
         true
     }
 
-    fn handle_message(&mut self, message: &Message, _server_tick: u32, _client_tick: u32, _parser_state: &ParserState) {
+    fn handle_message(
+        &mut self,
+        message: &Message,
+        _server_tick: u32,
+        _client_tick: u32,
+        _parser_state: &ParserState,
+    ) {
         self.packet_types.push(message.get_message_type())
     }
 

--- a/src/demo/parser/messagetypeanalyser.rs
+++ b/src/demo/parser/messagetypeanalyser.rs
@@ -16,7 +16,7 @@ impl MessageHandler for MessageTypeAnalyser {
         true
     }
 
-    fn handle_message(&mut self, message: &Message, _tick: u32, _parser_state: &ParserState) {
+    fn handle_message(&mut self, message: &Message, _server_tick: u32, _client_tick: u32, _parser_state: &ParserState) {
         self.packet_types.push(message.get_message_type())
     }
 

--- a/src/demo/parser/state.rs
+++ b/src/demo/parser/state.rs
@@ -221,7 +221,7 @@ impl<'a> ParserState {
         )
     }
 
-    pub fn handle_message(&mut self, message: Message, _tick: u32) {
+    pub fn handle_message(&mut self, message: Message, _server_tick: u32) {
         match message {
             Message::ServerInfo(message) => {
                 self.demo_meta.version = message.version;

--- a/src/demo/vector.rs
+++ b/src/demo/vector.rs
@@ -1,7 +1,7 @@
-use std::ops::{Add, Sub};
 use bitbuffer::{BitRead, BitWrite};
 use parse_display::Display;
 use serde::{Deserialize, Serialize};
+use std::ops::{Add, Sub};
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(BitRead, BitWrite, Debug, Clone, Copy, Default, Serialize, Deserialize, Display)]

--- a/tests/entity.rs
+++ b/tests/entity.rs
@@ -94,13 +94,19 @@ impl MessageHandler for EntityDumper {
         }
     }
 
-    fn handle_message(&mut self, message: &Message, tick: u32, _parser_state: &ParserState) {
+    fn handle_message(
+        &mut self,
+        message: &Message,
+        server_tick: u32,
+        _client_tick: u32,
+        _parser_state: &ParserState
+    ) {
         match message {
             Message::PacketEntities(entity_message) => self.entities.extend(
                 entity_message
                     .entities
                     .iter()
-                    .map(|entity| (tick, entity.clone())),
+                    .map(|entity| (server_tick, entity.clone())),
             ),
             _ => {}
         }

--- a/tests/message_reencode.rs
+++ b/tests/message_reencode.rs
@@ -73,5 +73,5 @@ fn setup_message(handler: &mut DemoHandler<NullHandler>, input: &str) {
         &handler.state_handler,
     )
     .unwrap();
-    handler.handle_message(message);
+    handler.handle_message(message, 0);
 }


### PR DESCRIPTION
This PR clarifies the different types of ticks by adjusting variable names, and message handlers are now given both tick types as arguments.

Please let me know if you would implement this differently - I'm open for any feedback.

I have a few open questions:
- At `src/demo/parser/state.rs:224`: Should we add client_tick here? I left it out because even server_tick is currently unused.
- At `tests/message_reencode.rs:76`: is 0 ok as a default here? It doesn't seem to matter as long as the `NullHandler` is used.

Also, I removed a redundant match arm in `src/demo/parser/handler.rs:134`.