### PR TITLE
Add simtime & PVS flag to Player struct

### DIFF
--- a/src/demo/message/packetentities.rs
+++ b/src/demo/message/packetentities.rs
@@ -657,7 +657,7 @@ fn test_packet_entitier_message_roundtrip() {
                             value: SendPropValue::Float(1.0),
                         },
                     ],
-                    in_pvs: false,
+                    in_pvs: true,
                     update_type: UpdateType::Preserve,
                     serial_number: 0,
                     delay: None,

--- a/src/demo/message/packetentities.rs
+++ b/src/demo/message/packetentities.rs
@@ -316,6 +316,7 @@ impl Parse<'_> for PacketEntitiesMessage {
                 let send_table = get_send_table(state, entity.server_class)?;
 
                 Self::read_update(&mut data, send_table, &mut entity.props, entity_index)?;
+                entity.in_pvs = true;
 
                 entities.push(entity);
             } else if state.entity_classes.contains_key(&entity_index) {

--- a/src/demo/parser/gamestateanalyser.rs
+++ b/src/demo/parser/gamestateanalyser.rs
@@ -54,6 +54,8 @@ pub struct Player {
     pub state: PlayerState,
     pub info: Option<UserInfo>,
     pub charge: u8,
+    pub simtime: u16,
+    pub in_pvs: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
@@ -472,6 +474,11 @@ impl GameStateAnalyser {
             SendPropIdentifier::new("DT_TFLocalPlayerExclusive", "m_angEyeAngles[0]");
         const NON_LOCAL_PITCH_ANGLES: SendPropIdentifier =
             SendPropIdentifier::new("DT_TFNonLocalPlayerExclusive", "m_angEyeAngles[0]");
+            
+        const SIMTIME_PROP: SendPropIdentifier =
+        SendPropIdentifier::new("DT_BaseEntity", "m_flSimulationTime");
+
+        player.in_pvs = entity.in_pvs;
 
         for prop in entity.props(parser_state) {
             match prop.identifier {
@@ -497,6 +504,9 @@ impl GameStateAnalyser {
                 }
                 LOCAL_PITCH_ANGLES | NON_LOCAL_PITCH_ANGLES => {
                     player.pitch_angle = f32::try_from(&prop.value).unwrap_or_default()
+                }
+                SIMTIME_PROP => {
+                    player.simtime = i64::try_from(&prop.value).unwrap_or_default() as u16
                 }
                 _ => {}
             }

--- a/test_data/gully_game_state.json
+++ b/test_data/gully_game_state.json
@@ -21,7 +21,9 @@
         "steamId": "[U:1:78023051]",
         "team": "other"
       },
-      "charge": 0
+      "charge": 0,
+      "simtime": 89,
+      "in_pvs": true
     },
     {
       "entity": 3,
@@ -44,7 +46,9 @@
         "steamId": "[U:1:151261665]",
         "team": "other"
       },
-      "charge": 0
+      "charge": 0,
+      "simtime": 85,
+      "in_pvs": false
     },
     {
       "entity": 4,
@@ -67,7 +71,9 @@
         "steamId": "[U:1:105458702]",
         "team": "other"
       },
-      "charge": 0
+      "charge": 0,
+      "simtime": 80,
+      "in_pvs": false
     },
     {
       "entity": 5,
@@ -90,7 +96,9 @@
         "steamId": "[U:1:81747492]",
         "team": "other"
       },
-      "charge": 0
+      "charge": 0,
+      "simtime": 92,
+      "in_pvs": true
     },
     {
       "entity": 6,
@@ -113,7 +121,9 @@
         "steamId": "[U:1:50363269]",
         "team": "other"
       },
-      "charge": 0
+      "charge": 0,
+      "simtime": 85,
+      "in_pvs": false
     },
     {
       "entity": 7,
@@ -136,7 +146,9 @@
         "steamId": "[U:1:192228451]",
         "team": "other"
       },
-      "charge": 0
+      "charge": 0,
+      "simtime": 87,
+      "in_pvs": false
     },
     {
       "entity": 8,
@@ -159,7 +171,9 @@
         "steamId": "[U:1:103356736]",
         "team": "other"
       },
-      "charge": 0
+      "charge": 0,
+      "simtime": 83,
+      "in_pvs": false
     },
     {
       "entity": 9,
@@ -182,7 +196,9 @@
         "steamId": "[U:1:85558037]",
         "team": "other"
       },
-      "charge": 0
+      "charge": 0,
+      "simtime": 84,
+      "in_pvs": false
     },
     {
       "entity": 10,
@@ -205,7 +221,9 @@
         "steamId": "[U:1:101328438]",
         "team": "other"
       },
-      "charge": 0
+      "charge": 0,
+      "simtime": 86,
+      "in_pvs": false
     },
     {
       "entity": 11,
@@ -228,7 +246,9 @@
         "steamId": "[U:1:63292929]",
         "team": "other"
       },
-      "charge": 0
+      "charge": 0,
+      "simtime": 88,
+      "in_pvs": false
     },
     {
       "entity": 12,
@@ -251,7 +271,9 @@
         "steamId": "[U:1:91304212]",
         "team": "other"
       },
-      "charge": 0
+      "charge": 0,
+      "simtime": 81,
+      "in_pvs": false
     },
     {
       "entity": 13,
@@ -274,7 +296,9 @@
         "steamId": "[U:1:82128674]",
         "team": "other"
       },
-      "charge": 0
+      "charge": 0,
+      "simtime": 83,
+      "in_pvs": false
     }
   ],
   "buildings": {},

--- a/test_data/small_game_state.json
+++ b/test_data/small_game_state.json
@@ -21,7 +21,9 @@
         "steamId": "[U:1:64229260]",
         "team": "other"
       },
-      "charge": 0
+      "charge": 0,
+      "simtime": 78,
+      "in_pvs": true
     }
   ],
   "buildings": {},


### PR DESCRIPTION
Hi, I'm working on MegaAntiCheat's demo parsing functionality at the moment, and we need some extra fields to make use of the resulting data - particularly simtime, which indicates how many ticks have occured for a particular player, and their current PVS state.
As to the PVS state, I've noticed that it's not correctly tracked, as it's set to `false` for Preserve updates, so I added a line to set it to true in the Preserve update branch.
I've added fields `simtime` and `in_pvs` to the Player struct. `in_pvs` is simply sourced from the PacketEntity, and `simtime` is sourced from the netvar `DT_BaseEntity->m_flSimulationTime`.
Thanks!