### PR TITLE
feat: Expose PInvoke-able analyzers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.70.0"
 [lib]
 name = "tf_demo_parser"
 path = "src/lib.rs"
+crate-type = ["lib", "cdylib"]
 
 [[bin]]
 name = "parse_demo"


### PR DESCRIPTION
I'm not huge on rust, so feel free to be brutal in code review, or decline this PR

This is a stab at allowing the DLLs to be invoked by other languages (e.g. C#)

I have a sample repo using this change (passing tests!)

https://github.com/Hona/demostf-parser-dotnet

Integration test that invokes & asserts something about the data out :)
https://github.com/Hona/demostf-parser-dotnet/blob/master/DemosTF.Parser.NET.Tests/IntegrationTests.cs#L29-L46