### PR TITLE
Add SendPropIdentifier::from_const

### DIFF
--- a/src/demo/sendprop.rs
+++ b/src/demo/sendprop.rs
@@ -1113,6 +1113,12 @@ impl SendPropIdentifier {
         SendPropIdentifier(hasher.finish())
     }
 
+    /// Construct a SendPropIdentifier from a u64; like std::convert::From<u64> but marked as
+    /// const.
+    pub const fn from_const(raw: u64) -> Self {
+        SendPropIdentifier(raw)
+    }
+
     /// This returns an option because only props known at compile time will return a name here
     ///
     /// If you need to know the name of every property you need to keep a map yourself


### PR DESCRIPTION
Minor API addition to allow making consts for SendProps without needing to figure out the original table/prop name.

```rust
 const NUM_COSMETICS: SendPropIdentifier =
      SendPropIdentifier::from_const(12394170462905005439);
```

This is like the existing `From<u64>` impl; but marked const (sadly, Rust is still a long way off from const fns in traits https://github.com/rust-lang/rfcs/pull/3490)